### PR TITLE
Update OPCUA south plugin naming scheme

### DIFF
--- a/include/opcua.h
+++ b/include/opcua.h
@@ -33,7 +33,7 @@ class OPCUA
 		void		subscribeById(bool byId) { m_subscribeById = byId; };
 		void		start();
 		void		stop();
-		void		ingest(std::vector<Datapoint *>  points);
+		void		ingest(std::vector<Datapoint *> & points, OpcUa::DateTime sourceTimestamp);
 		void		setReportingInterval(long value);
 		void		registerIngest(void *data, void (*cb)(void *, Reading))
 				{
@@ -61,11 +61,12 @@ class OpcUaClient : public OpcUa::SubscriptionHandler
 { 
 	public:
 	  	OpcUaClient(OPCUA *opcua) : m_opcua(opcua) {};
-		void DataChange(uint32_t handle,
+		void DataValueChange(uint32_t handle,
 				const OpcUa::Node & node,
-				const OpcUa::Variant & val,
+				const OpcUa::DataValue & dval,
 				OpcUa::AttributeId attr) override
 		{
+			OpcUa::Variant val(dval.Value);
 			if (val.IsNul())
 				return;
 			// We don't support non-scalar or Nul values as conversion
@@ -308,7 +309,7 @@ class OpcUaClient : public OpcUa::SubscriptionHandler
 				dpname.erase(pos, 1);
 			}
 			points.push_back(new Datapoint(dpname, value));
-			m_opcua->ingest(points);
+			m_opcua->ingest(points, dval.SourceTimestamp);
 		};
 	private:
 		OPCUA		*m_opcua;

--- a/include/opcua.h
+++ b/include/opcua.h
@@ -18,6 +18,16 @@
 #include <mutex>
 #include <stdlib.h>
 
+enum class AssetNameType
+{
+	NodeIdAsName,
+	BrowseAsName,
+	SubscriptionWithNodeId,
+	SubscriptionWithBrowseName,
+	FullPathWithNodeId,
+	FullPathWithBrowseName
+};
+
 class OpcUaClient;
 
 class OPCUA
@@ -28,12 +38,16 @@ class OPCUA
 		void		clearSubscription();
 		void		addSubscription(const std::string& parent);
 		void		setAssetName(const std::string& name);
+		void		setPathDelimiter(const std::string& delmiter);
+		void		setAssetNameSource(const std::string& assetNameSource);
+		std::string	getAssetPath(const OpcUa::NodeId& nodeId);
+		std::string getNodeName(const OpcUa::Node& node);
 		void		restart();
 		void		newURL(const std::string& url) { m_url = url; };
 		void		subscribeById(bool byId) { m_subscribeById = byId; };
 		void		start();
 		void		stop();
-		void		ingest(std::vector<Datapoint *> & points, OpcUa::DateTime sourceTimestamp);
+		void		ingest(std::vector<Datapoint *> & points, const std::string & assetPath, OpcUa::DateTime sourceTimestamp);
 		void		setReportingInterval(long value);
 		void		registerIngest(void *data, void (*cb)(void *, Reading))
 				{
@@ -42,10 +56,11 @@ class OPCUA
 				}
 
 	private:
-		int				addSubscribe(const OpcUa::Node& node, bool active);
+		int					addSubscribe(const OpcUa::Node& node, std::string& subscriptionParentPath, bool active);
 		std::vector<std::string>	m_subscriptions;
 		std::string			m_url;
 		std::string			m_asset;
+		std::string			m_pathDelimiter;
 		OpcUa::UaClient			*m_client;
 		void				(*m_ingest)(void *, Reading);
 		void				*m_data;
@@ -54,7 +69,13 @@ class OPCUA
 		std::mutex			m_configMutex;
 		bool				m_subscribeById;
 		bool				m_connected;
+		bool				m_useBrowseName;
 		long				m_reportingInterval;
+		AssetNameType		m_assetNameType;
+		std::map<OpcUa::NodeId, std::string> m_assetPathNames;
+		std::string			createAssetName(const OpcUa::Node& node, const std::string subscriptionPath);
+		std::string			NodeIdString(const OpcUa::Node& node);
+		void				getNodeFullPath(const OpcUa::Node& node, std::string& fullPath);
 };
 
 class OpcUaClient : public OpcUa::SubscriptionHandler
@@ -286,30 +307,20 @@ class OpcUaClient : public OpcUa::SubscriptionHandler
 			}
 
 			std::vector<Datapoint *> points;
-			std::string dpname = "Unknown";;
-			try {
-				OpcUa::NodeId id = node.GetId();
-				if (id.IsInteger())
-				{
-					char buf[80];
-					snprintf(buf, sizeof(buf), "%d", id.GetIntegerIdentifier());
-					dpname = buf;
-				}
-				else
-				{
-					dpname = node.GetId().GetStringIdentifier();
-				}
-			} catch (std::exception& e) {
-				Logger::getLogger()->error("No name for data change event: %s", e.what());
+			std::string dpname = m_opcua->getNodeName(node);
+
+			if (dpname.length() == 0) {
+				Logger::getLogger()->error("No name for data change event: %s", m_opcua->getAssetPath(node.GetId()));
 			}
-			// Strip " from datapoint name
+
+			// Strip " from Datapoint name
 			size_t pos;
 			while ((pos = dpname.find_first_of("\"")) != std::string::npos)
 			{
 				dpname.erase(pos, 1);
 			}
 			points.push_back(new Datapoint(dpname, value));
-			m_opcua->ingest(points, dval.SourceTimestamp);
+			m_opcua->ingest(points, m_opcua->getAssetPath(node.GetId()), dval.SourceTimestamp);
 		};
 	private:
 		OPCUA		*m_opcua;

--- a/plugin.cpp
+++ b/plugin.cpp
@@ -62,12 +62,33 @@ static const char *default_config = QUOTE({
 		"displayName" : "Subscribe By ID",
 		"order" : "4"
 		},
+	"assetNameType" : {
+		"description" : "Name from the OPC UA Server's namespace to use as the Asset name",
+		"type" : "enumeration",
+		"options" : [
+			"NodeId",
+			"BrowseName",
+			"Subscription Path with NodeId",
+			"Subscription Path with BrowseName",
+			"Full Path with NodeId",
+			"Full Path with BrowseName" ],
+		"displayName" : "Asset Name Source",
+		"default" : "NodeId",
+		"order" : "5"
+		},
+	"pathDelimiter" : {
+		"description" : "Single-character delimiter to use in Asset path names",
+		"type" : "string",
+		"default" : "/",
+		"displayName" : "Asset Path Delimiter",
+		"order" : "6"
+		},
 	"reportingInterval" : {
 		"description" : "The minimum reporting interval for data change notifications" ,
 		"type" : "integer",
 		"default" : "100",
 		"displayName" : "Min Reporting Interval",
-		"order" : "5"
+		"order" : "7"
 		}
 	});
 
@@ -148,6 +169,26 @@ string	url;
 		{
 			opcua->subscribeById(false);
 		}
+	}
+
+	if (config->itemExists("assetNameType"))
+	{
+		string assetNameType = config->getValue("assetNameType");
+		opcua->setAssetNameSource(assetNameType);
+	}
+	else
+	{
+		opcua->setAssetNameSource("");
+	}
+
+	if (config->itemExists("pathDelimiter"))
+	{
+		string pathDelimiter = config->getValue("pathDelimiter");
+		opcua->setPathDelimiter(pathDelimiter);
+	}
+	else
+	{
+		opcua->setPathDelimiter("");
 	}
 
 	// Now add the subscription data
@@ -251,6 +292,26 @@ OPCUA		*opcua = (OPCUA *)*handle;
 		{
 			opcua->subscribeById(false);
 		}
+	}
+
+	if (config.itemExists("assetNameType"))
+	{
+		string assetNameType = config.getValue("assetNameType");
+		opcua->setAssetNameSource(assetNameType);
+	}
+	else
+	{
+		opcua->setAssetNameSource("");
+	}
+
+	if (config.itemExists("pathDelimiter"))
+	{
+		string pathDelimiter = config.getValue("pathDelimiter");
+		opcua->setPathDelimiter(pathDelimiter);
+	}
+	else
+	{
+		opcua->setPathDelimiter("");
 	}
 
 	if (config.itemExists("subscription"))


### PR DESCRIPTION
Add options for generating a name for the Asset using information from the OPC UA Node. Also use the OPC UA data source timestamp as the User Timestamp in Fledge.